### PR TITLE
Adding travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: cpp
+os: osx
+osx_image: xcode7.3
+
+env:
+  - BUILD_TOOL=Xcode
+  - BUILD_TOOL=CMake
+
+git:
+  submodules: false
+
+branches:
+  only:
+    - master
+
+compiler:
+  - clang
+
+before_script:
+  # Take care of dependencies.
+  - sed -i '' 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  - ./setup minimal
+  - >
+    xcodebuild -configuration Release -target emptyExample
+    -project "third-party/openFrameworks/scripts/templates/osx/emptyExample.xcodeproj"
+  # CMake
+  - >
+    if [ "$BUILD_TOOL" = "CMake" ]; then
+      mkdir build
+      cd build
+      cmake ..
+    fi
+script:
+  - >
+    if [ "$BUILD_TOOL" = "CMake" ]; then
+      make;
+    fi;
+  - >
+    if [ "$BUILD_TOOL" = "Xcode" ]; then
+      xcodebuild -configuration Release -target ESP -project "Xcode/ESP/ESP.xcodeproj"
+    fi
+cache:
+  directories:
+    - third-party/openFrameworks/libs


### PR DESCRIPTION
This allows continuous testing of the build process of our project (gaining confidence for distributing this as an open source project).

Current configuration builds the project in two ways: 1. Xcode; 2. CMake

See the page of the [build](https://travis-ci.org/nebgnahz/ESP-CI) using my [fork](https://github.com/nebgnahz/ESP-CI).