### PR TITLE
feat(ui): advanced feature view

### DIFF
--- a/Xcode/ESP/src/ofApp.cpp
+++ b/Xcode/ESP/src/ofApp.cpp
@@ -286,9 +286,9 @@ void ofApp::setup() {
     }
 
     // 2. Parse pre-processing.
-    uint32_t num_feature_modules = pipeline_->getNumFeatureExtractionModules();
+    num_feature_modules_ = pipeline_->getNumFeatureExtractionModules();
     uint32_t num_final_features = 0;
-    for (int i = 0; i < num_feature_modules; i++) {
+    for (int i = 0; i < num_feature_modules_; i++) {
         vector<ofxGrtTimeseriesPlot> feature_at_stage_i;
 
         FeatureExtraction* fe = pipeline_->getFeatureExtractionModule(i);
@@ -324,7 +324,7 @@ void ofApp::setup() {
         plot_features_.push_back(feature_at_stage_i);
 
         // the final stage feature is also used for live plots
-        if (i == num_feature_modules - 1) {
+        if (i == num_feature_modules_ - 1) {
             plot_live_features_ = feature_at_stage_i;
         }
     }
@@ -1388,7 +1388,7 @@ void ofApp::update() {
         }
 
         // live feature data
-        {
+        if (num_feature_modules_ > 0) {
             vector<double> data = pipeline_->getFeatureExtractionData(
                 pipeline_->getNumFeatureExtractionModules() - 1);
 
@@ -1949,6 +1949,12 @@ void ofApp::onDataIn(GRT::MatrixDouble input) {
 //--------------------------------------------------------------
 void ofApp::toggleFeatureView() {
     ESP_EVENT("Toggle Feature View");
+    setStatus("This pipeline doesn't have any feature extraction module");
+
+    if (num_feature_modules_ == 0) {
+        // Then this function is a no-op
+        return;
+    }
 
     if (is_in_feature_view_) {
         is_in_feature_view_ = false;

--- a/Xcode/ESP/src/ofApp.cpp
+++ b/Xcode/ESP/src/ofApp.cpp
@@ -1403,15 +1403,14 @@ void ofApp::update() {
             }
         }
 
-        // Till this point, either `pipeline_->predict` or
-        // `pipeline->preProcessData` has been called. It's safe to directly get
-        // the data and update the plots in the PIPELINE tab.
-        if (istream_->hasStarted() &&
-            (calibrator_ == NULL || calibrator_->isCalibrated()) &&
-            fragment_ == PIPELINE) {
-
-            int j = 0;;
+        // At pipeline state implicitly means that the istream has started
+        // and the calibration is done
+        if (state_ == AppState::kPipeline) {
+            int j = 0;
             vector<double> data = data_point;
+            // Till this point, either `pipeline_->predict` or
+            // `pipeline->preProcessData` has been called. It's safe to directly
+            // get the data and update the plots in the PIPELINE tab.
 
             // Pre-processed data
             for (j = 0; j < pipeline_->getNumPreProcessingModules(); j++) {

--- a/Xcode/ESP/src/ofApp.cpp
+++ b/Xcode/ESP/src/ofApp.cpp
@@ -1600,7 +1600,24 @@ void ofApp::drawInputs(uint32_t stage_left, uint32_t stage_top,
 
 void ofApp::drawLiveFeatures(uint32_t stage_left, uint32_t stage_top,
                              uint32_t stage_width, uint32_t stage_height) {
-    // Only the last feature vectors
+    // Two cases here:
+    //   1. feature is a high-dimension data and we choose to show the snapshot,
+    //      then we use 1/5 of the space to show the live data as a timeline
+    //   2. feature itself is a time-series data, simply draw the features
+    //
+    // In the first case, we modify the allocated space for the features,
+    // i.e. modify stage_top and stage_height so that we can reuse the code that
+    // draws the features.
+    if (is_final_features_too_many_) {
+        uint32_t height = stage_height / 5;
+        drawInputs(stage_left, stage_top, stage_width, height);
+
+        // modify the stage height
+        uint32_t margin = 10;
+        stage_top = stage_top + (height + margin);
+        stage_height = stage_height - (height + margin);
+    }
+
     uint32_t height = stage_height / plot_live_features_.size();
 
     for (int j = 0; j < plot_live_features_.size(); j++) {

--- a/Xcode/ESP/src/ofApp.cpp
+++ b/Xcode/ESP/src/ofApp.cpp
@@ -273,6 +273,10 @@ void ofApp::setup() {
     // Parse the user supplied pipeline and extract information:
     //  o num_pipeline_stages_
 
+    // num_final_features will be the last stage of processing (either
+    // pre-processing or feature extraction).
+    uint32_t num_final_features = 0;
+
     // 1. Parse pre-processing.
     num_preprocessing_modules_ = pipeline_->getNumPreProcessingModules();
     num_pipeline_stages_ += num_preprocessing_modules_;
@@ -292,11 +296,12 @@ void ofApp::setup() {
         if (i == num_preprocessing_modules_ - 1) {
             plot_live_features_.push_back(plot);
         }
+
+        num_final_features = dim;
     }
 
     // 2. Parse features.
     num_feature_modules_ = pipeline_->getNumFeatureExtractionModules();
-    uint32_t num_final_features = 0;
     for (int i = 0; i < num_feature_modules_; i++) {
         vector<ofxGrtTimeseriesPlot> feature_at_stage_i;
 
@@ -540,7 +545,7 @@ vector<double> ofApp::getLastStageProcessedData() const {
 }
 
 void ofApp::populateSampleFeatures(uint32_t sample_index) {
-    if (pipeline_->getNumFeatureExtractionModules() == 0) { return; }
+    if (num_preprocessing_modules_ + num_feature_modules_ == 0) { return; }
 
     // Clean up historical data/caches.
     pipeline_->reset();
@@ -1810,8 +1815,8 @@ void ofApp::drawTrainingInfo() {
             plot_samples_[i].draw(x, stage_top, width, sample_height);
         }
 
-        // draw features if requested (only draw actual features right now...
-        if (is_in_feature_view_ && num_feature_modules_ > 0) {
+        // draw features if requested
+        if (is_in_feature_view_) {
             uint32_t x = stage_left + i * width;
             uint32_t y = stage_top + sample_height + margin / 4;
             vector<Plotter> feature_plots = plot_sample_features_[i];

--- a/Xcode/ESP/src/ofApp.h
+++ b/Xcode/ESP/src/ofApp.h
@@ -155,10 +155,17 @@ class ofApp : public ofBaseApp, public GRT::Observer<GRT::ErrorLogMessage> {
     // Pipeline, tuneables and all data
     //========================================================================
     GRT::GestureRecognitionPipeline *pipeline_;
-    // The number of pipeline stages, this will control the UI layout. The
-    // number is obtained during setup() and used in draw().
+
+    // The number of pipeline stages will control the UI layout. The number is
+    // obtained during setup() and used in draw().
     uint32_t num_pipeline_stages_;
+
+    // These two variables just track the number of pre-processing modules and
+    // feature extraction modules so that we can control what data to read for
+    // getLastStageProcessedData.
+    uint32_t num_preprocessing_modules_;
     uint32_t num_feature_modules_;
+    vector<double> getLastStageProcessedData() const;
 
     vector<Tuneable*> tuneable_parameters_;
     Calibrator* calibrator_;

--- a/Xcode/ESP/src/ofApp.h
+++ b/Xcode/ESP/src/ofApp.h
@@ -106,6 +106,8 @@ class ofApp : public ofBaseApp, public GRT::Observer<GRT::ErrorLogMessage> {
     }
 
     void drawInputs(uint32_t, uint32_t, uint32_t, uint32_t);
+    void drawLiveFeatures(uint32_t, uint32_t, uint32_t, uint32_t);
+
     void drawCalibration();
     void drawLivePipeline();
     void drawTrainingInfo();
@@ -238,6 +240,7 @@ class ofApp : public ofBaseApp, public GRT::Observer<GRT::ErrorLogMessage> {
     // visual: live plots are across all tabs
     //========================================================================
     InteractiveTimeSeriesPlot plot_inputs_;
+    vector<ofxGrtTimeseriesPlot> plot_live_features_;  // live features
     ofxGrtTimeseriesPlot plot_inputs_snapshot_;  // a spectrum of the most
                                                  // recent input vector, shown
                                                  // only if the number of input

--- a/Xcode/ESP/src/ofApp.h
+++ b/Xcode/ESP/src/ofApp.h
@@ -158,6 +158,7 @@ class ofApp : public ofBaseApp, public GRT::Observer<GRT::ErrorLogMessage> {
     // The number of pipeline stages, this will control the UI layout. The
     // number is obtained during setup() and used in draw().
     uint32_t num_pipeline_stages_;
+    uint32_t num_feature_modules_;
 
     vector<Tuneable*> tuneable_parameters_;
     Calibrator* calibrator_;


### PR DESCRIPTION
1. On analysis, training, and prediction tabs, show the features from the last stage live if 'f' is pressed
2. On the training data view, the live data is replaced with features (as in 1); at the same time, the training sample plot is shortened and the adjoining feature plots are shown. Right now, the features are still computed on the fly (calling `populateSampleFeatures`). Ideally the features could have been saved [1].

[1] To save the features, then we need a vector of vectors holding all the feature data; they are for each class and each sample. It seems to make sense to implement this in the training data manager. I am leaving that as a future (separate) change request.

References #136 