### PR TITLE
fix(build): update VS project and fix TCP error

### DIFF
--- a/Xcode/ESP/ESP.vcxproj
+++ b/Xcode/ESP/ESP.vcxproj
@@ -98,7 +98,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\third-party\openFrameworks\addons\ofxDatGui\src;..\..\third-party\openFrameworks\addons\ofxDatGui\src\components;..\..\third-party\openFrameworks\addons\ofxDatGui\src\core;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs\ofxSmartFont;..\..\third-party\openFrameworks\addons\ofxDatGui\src\themes;..\..\third-party\openFrameworks\addons\ofxGrt\src;..\..\third-party\openFrameworks\addons\ofxGrt\libs\grt;..\..\third-party\openFrameworks\addons\ofxNetwork\src;..\..\third-party\openFrameworks\addons\ofxParagraph\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\third-party\openFrameworks\addons\ofxDatGui\src;..\..\third-party\openFrameworks\addons\ofxDatGui\src\components;..\..\third-party\openFrameworks\addons\ofxDatGui\src\core;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs\ofxSmartFont;..\..\third-party\openFrameworks\addons\ofxDatGui\src\themes;..\..\third-party\openFrameworks\addons\ofxGrt\src;..\..\third-party\openFrameworks\addons\ofxGrt\libs\grt;..\..\third-party\openFrameworks\addons\ofxNetwork\src;..\..\third-party\openFrameworks\addons\ofxParagraph\src;..\..\third-party\openFrameworks\addons\ofxOsc\src;..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src;..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc;..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <Link>
@@ -117,7 +117,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\third-party\openFrameworks\addons\ofxDatGui\src;..\..\third-party\openFrameworks\addons\ofxDatGui\src\components;..\..\third-party\openFrameworks\addons\ofxDatGui\src\core;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs\ofxSmartFont;..\..\third-party\openFrameworks\addons\ofxDatGui\src\themes;..\..\third-party\openFrameworks\addons\ofxGrt\src;..\..\third-party\openFrameworks\addons\ofxGrt\libs\grt;..\..\third-party\openFrameworks\addons\ofxNetwork\src;..\..\third-party\openFrameworks\addons\ofxParagraph\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\third-party\openFrameworks\addons\ofxDatGui\src;..\..\third-party\openFrameworks\addons\ofxDatGui\src\components;..\..\third-party\openFrameworks\addons\ofxDatGui\src\core;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs\ofxSmartFont;..\..\third-party\openFrameworks\addons\ofxDatGui\src\themes;..\..\third-party\openFrameworks\addons\ofxGrt\src;..\..\third-party\openFrameworks\addons\ofxGrt\libs\grt;..\..\third-party\openFrameworks\addons\ofxNetwork\src;..\..\third-party\openFrameworks\addons\ofxParagraph\src;..\..\third-party\openFrameworks\addons\ofxOsc\src;..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src;..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc;..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -136,7 +136,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\third-party\openFrameworks\addons\ofxDatGui\src;..\..\third-party\openFrameworks\addons\ofxDatGui\src\components;..\..\third-party\openFrameworks\addons\ofxDatGui\src\core;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs\ofxSmartFont;..\..\third-party\openFrameworks\addons\ofxDatGui\src\themes;..\..\third-party\openFrameworks\addons\ofxGrt\src;..\..\third-party\openFrameworks\addons\ofxGrt\libs\grt;..\..\third-party\openFrameworks\addons\ofxNetwork\src;..\..\third-party\openFrameworks\addons\ofxParagraph\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\third-party\openFrameworks\addons\ofxDatGui\src;..\..\third-party\openFrameworks\addons\ofxDatGui\src\components;..\..\third-party\openFrameworks\addons\ofxDatGui\src\core;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs\ofxSmartFont;..\..\third-party\openFrameworks\addons\ofxDatGui\src\themes;..\..\third-party\openFrameworks\addons\ofxGrt\src;..\..\third-party\openFrameworks\addons\ofxGrt\libs\grt;..\..\third-party\openFrameworks\addons\ofxNetwork\src;..\..\third-party\openFrameworks\addons\ofxParagraph\src;..\..\third-party\openFrameworks\addons\ofxOsc\src;..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src;..\..\third-party\openFrameworks\addons\ofxOsc\src\oscpack\src\osc;..\..\third-party\openFrameworks\addons\ofxOsc\src\oscpack\src\ip</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -158,7 +158,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\third-party\openFrameworks\addons\ofxDatGui\src;..\..\third-party\openFrameworks\addons\ofxDatGui\src\components;..\..\third-party\openFrameworks\addons\ofxDatGui\src\core;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs\ofxSmartFont;..\..\third-party\openFrameworks\addons\ofxDatGui\src\themes;..\..\third-party\openFrameworks\addons\ofxGrt\src;..\..\third-party\openFrameworks\addons\ofxGrt\libs\grt;..\..\third-party\openFrameworks\addons\ofxNetwork\src;..\..\third-party\openFrameworks\addons\ofxParagraph\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;..\..\third-party\openFrameworks\addons\ofxDatGui\src;..\..\third-party\openFrameworks\addons\ofxDatGui\src\components;..\..\third-party\openFrameworks\addons\ofxDatGui\src\core;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs;..\..\third-party\openFrameworks\addons\ofxDatGui\src\libs\ofxSmartFont;..\..\third-party\openFrameworks\addons\ofxDatGui\src\themes;..\..\third-party\openFrameworks\addons\ofxGrt\src;..\..\third-party\openFrameworks\addons\ofxGrt\libs\grt;..\..\third-party\openFrameworks\addons\ofxNetwork\src;..\..\third-party\openFrameworks\addons\ofxParagraph\src;..\..\third-party\openFrameworks\addons\ofxOsc\src;..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src;..\..\third-party\openFrameworks\addons\ofxOsc\src\oscpack\src\osc;..\..\third-party\openFrameworks\addons\ofxOsc\src\oscpack\src\ip</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
     </ClCompile>
     <Link>
@@ -174,6 +174,18 @@
     <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\IpEndpointName.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\win32\NetworkingUtils.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\win32\UdpSocket.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscOutboundPacketStream.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscPrintReceivedElements.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscReceivedElements.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscTypes.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscBundle.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscMessage.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscParameterSync.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscReceiver.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscSender.cpp" />
     <ClCompile Include="src\calibrator.cpp" />
     <ClCompile Include="src\Filter.cpp" />
     <ClCompile Include="src\iostream.cpp" />
@@ -201,6 +213,26 @@
     <ClCompile Include="src\user.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\IpEndpointName.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\NetworkingUtils.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\PacketListener.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\TimerListener.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\UdpSocket.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\MessageMappingOscPacketListener.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscException.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscHostEndianness.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscOutboundPacketStream.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscPacketListener.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscPrintReceivedElements.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscReceivedElements.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscTypes.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOsc.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscArg.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscBundle.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscMessage.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscParameterSync.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscReceiver.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscSender.h" />
     <ClInclude Include="src\calibrator.h" />
     <ClInclude Include="src\ESP.h" />
     <ClInclude Include="src\Filter.h" />

--- a/Xcode/ESP/ESP.vcxproj.filters
+++ b/Xcode/ESP/ESP.vcxproj.filters
@@ -62,6 +62,18 @@
     <ClCompile Include="src\ofConsoleFileLoggerChannel.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscBundle.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscMessage.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscParameterSync.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscReceiver.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscSender.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\IpEndpointName.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\win32\NetworkingUtils.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\win32\UdpSocket.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscOutboundPacketStream.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscPrintReceivedElements.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscReceivedElements.cpp" />
+    <ClCompile Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscTypes.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="src">
@@ -193,6 +205,26 @@
     <ClInclude Include="src\ofConsoleFileLoggerChannel.h">
       <Filter>src</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOsc.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscArg.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscBundle.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscMessage.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscParameterSync.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscReceiver.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\src\ofxOscSender.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\IpEndpointName.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\NetworkingUtils.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\PacketListener.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\TimerListener.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\ip\UdpSocket.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\MessageMappingOscPacketListener.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscException.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscHostEndianness.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscOutboundPacketStream.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscPacketListener.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscPrintReceivedElements.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscReceivedElements.h" />
+    <ClInclude Include="..\..\third-party\openFrameworks\addons\ofxOsc\libs\oscpack\src\osc\OscTypes.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="icon.rc" />

--- a/Xcode/ESP/src/istream.h
+++ b/Xcode/ESP/src/istream.h
@@ -10,7 +10,6 @@
 
 #include "GRT/GRT.h"
 #include "ofMain.h"
-#include "ofxNetwork.h"
 #include "ofxOsc.h"
 #include "stream.h"
 
@@ -265,7 +264,7 @@ class TcpInputStream : public InputStream {
 
   private:
     void parseInput(const string& buffer);
-    ofxTCPServer server_;
+    ofxTCPServer* server_;
     unique_ptr<std::thread> reading_thread_;
     int port_num_;
     int dim_;

--- a/Xcode/ESP/src/ostream.h
+++ b/Xcode/ESP/src/ostream.h
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "ofxNetwork.h"
+#include "ofMain.h"
 #include "stream.h"
 
 const uint64_t kGracePeriod = 500; // 0.5 second


### PR DESCRIPTION
This is to address: #378 Windows build fails.

Fixes include:
1. update include dir for osc related headers
2. update all files in the project to include osc .cpp implementations
3. `istream.h` uses ofxTCPServer pointer to avoid include the actual implementation
4. add win sock include for istream.cpp (which uses ofxTCPServer)
5. in `ostream.cpp`, only include `ofMain` instead of `ofxNetwork` (this is traced with git bisect, see log below)
 
In general, it seems to be causing issue when we include `ofxNetwork` on Windows. It seems to work pretty well to have the following lines at the start of the corresponding file:

```
#ifdef TARGET_WIN32
#define _WINSOCKAPI_
#define WIN32_LEAN_AND_MEAN
#include <WinSock2.h>
#include <WS2tcpip.h>
#include <Windows.h>
#endif
```

Git bisect logs:
```
git bisect start
# bad: [fe77f0fd610a4769d61a94309a7c4ecca014bd1a] feat(ui): add customizable interface
git bisect bad fe77f0fd610a4769d61a94309a7c4ecca014bd1a
# good: [2c71baee49110e00faa82b5b424afa18e1db535a] Change speaker identification output stream to TCP.
git bisect good 2c71baee49110e00faa82b5b424afa18e1db535a
# good: [2c71baee49110e00faa82b5b424afa18e1db535a] Change speaker identification output stream to TCP.
git bisect good 2c71baee49110e00faa82b5b424afa18e1db535a
# bad: [8977c3b18697ad7f75e67a946ab6a8f68089daf4] feat(travis): auto deploy documentations to s3
git bisect bad 8977c3b18697ad7f75e67a946ab6a8f68089daf4
# bad: [1de18007d86d851459d33db9bfea3ab086296380] feat(ofApp): adding AppState to create a scope
git bisect bad 1de18007d86d851459d33db9bfea3ab086296380
# good: [cc99e27895bd81ce69fb8d711d9fdfcf362b0aeb] Speaker example uses SVM; fixed bug on time units
git bisect good cc99e27895bd81ce69fb8d711d9fdfcf362b0aeb
# good: [9b136623f221fdeb5f99b66d4effc361a9de2346] style(plotter): format and clean dead code
git bisect good 9b136623f221fdeb5f99b66d4effc361a9de2346
# bad: [c9c2f27696cb1871bb80bb561c856ac224f7b95e] refactor(all): move APIs to ESP.h
git bisect bad c9c2f27696cb1871bb80bb561c856ac224f7b95e
# good: [fb773d6a3110ec0df47794101c654fdf008377af] feat(relabel): flash the source label
git bisect good fb773d6a3110ec0df47794101c654fdf008377af
# first bad commit: [c9c2f27696cb1871bb80bb561c856ac224f7b95e] refactor(all): move APIs to ESP.h
```